### PR TITLE
Update title class name

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ exports.decorateConfig = config => Object.assign({}, config, {
 	css: `
 		${config.css}
 
-		.tabs_title {
+		._title {
 			display: none !important;
 		}
 	`


### PR DESCRIPTION
Hyper 1.4.0 was released today and a lot of the class names changed in the UI, including the one that governs the title. This PR updates the class name so the package works as it previously did.