### PR TITLE
Revert title class

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ exports.decorateConfig = config => Object.assign({}, config, {
 	css: `
 		${config.css}
 
-		._title {
+		.tabs_title {
 			display: none !important;
 		}
 	`


### PR DESCRIPTION
Apparently the class name changes were unintentional... patch 1.4.2 was released today that reverted the class names back to how they were.